### PR TITLE
+ added docker image with supervisord

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+# Use the official image as a parent image.
+FROM python:3.8.5-slim-buster
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y git && \
+    apt-get install -y supervisor
+
+# Set the working directory.
+WORKDIR /usr/src
+RUN git clone https://github.com/web64/nlpserver.git
+WORKDIR /usr/src/nlpserver
+
+# Install dependencies
+RUN apt-get -y install pkg-config && \
+ 	apt-get -y install -y python-numpy libicu-dev && \
+ 	apt-get -y install -y python3-pip && \
+ 	python3 -m pip install -r requirements.txt
+
+# Download language models
+RUN polyglot download LANG:en && \
+ 	polyglot download LANG:es 
+
+RUN python3 -m spacy download en && \
+	python3 -m spacy download es && \
+	python3 -m spacy download xx
+
+# Set supervisor config
+COPY nlpserver.conf /etc/supervisor/conf.d
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ 
+EXPOSE 6400

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,9 @@ RUN apt-get -y install pkg-config && \
  	python3 -m pip install -r requirements.txt
 
 # Download language models
-RUN polyglot download LANG:en && \
- 	polyglot download LANG:es 
+RUN polyglot download LANG:en
 
 RUN python3 -m spacy download en && \
-	python3 -m spacy download es && \
 	python3 -m spacy download xx
 
 # Set supervisor config

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,18 @@
+# NLP Server Docker image
+
+Docker slim image with NLP Server
+ 
+## Image creation
+
+Inside the docker folder run 
+```
+ docker build . --tag nlpserver:1.0
+
+ docker run --publish 6400:6400 --detach --name nlpserver nlpserver:1.0  
+
+```
+
+For CoreNLP on another container run:
+```
+docker run -p 9000:9000 nlpbox/corenlp
+``` 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+/usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
+supervisorctl reread
+supervisorctl update
+supervisorctl start nlpserver 

--- a/docker/nlpserver.conf
+++ b/docker/nlpserver.conf
@@ -1,0 +1,7 @@
+[program:nlpserver]
+command=python3 /usr/src/nlpserver/nlpserver.py
+directory=/usr/src/nlpserver/
+autostart=true
+autorestart=unexpected
+stdout_logfile=/var/log/nlpserver.log
+stderr_logfile=/var/log/nlpserver-error.log 


### PR DESCRIPTION
The pulll request contains a folder `docker` with the most simple files to start nlpserver on a docker container.
It follows the `laravel forge` instructions and uses the official python:3.8.5-slim-buster base image.

I did not included the image since I think it's more transparent to build it yourself.  Also, the language models are hardcoded.

# NLP Server Docker image

## Image creation

Inside the docker folder run 
```
 docker build . --tag nlpserver:1.0

 docker run --publish 6400:6400 --detach --name nlpserver nlpserver:1.0  

```
For CoreNLP on another container run:
```
docker run -p 9000:9000 nlpbox/corenlp
``` 